### PR TITLE
Updated references to scikit-learn and pandas modules.

### DIFF
--- a/notebook/Tour de SciKit-Learn.ipynb
+++ b/notebook/Tour de SciKit-Learn.ipynb
@@ -23,12 +23,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
+    "%config InlineBackend.figure_format='retina'\n",
     "\n",
     "# Things we'll need later\n",
     "import time\n",
@@ -38,7 +37,7 @@
     "from sklearn.metrics import mean_squared_error as mse\n",
     "from sklearn.metrics import r2_score\n",
     "from sklearn.metrics import classification_report\n",
-    "from sklearn import cross_validation as cv\n",
+    "from sklearn.model_selection import train_test_split\n",
     "\n",
     "# Load the example datasets\n",
     "from sklearn.datasets import load_boston\n",
@@ -46,6 +45,10 @@
     "from sklearn.datasets import load_diabetes\n",
     "from sklearn.datasets import load_digits\n",
     "from sklearn.datasets import load_linnerud\n",
+    "\n",
+    "# Load warnings to filter out future warnings\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
     "\n",
     "# Boston house prices dataset (reals, regression)\n",
     "boston = load_boston()\n",
@@ -78,13 +81,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from pandas.tools.plotting import scatter_matrix, radviz\n",
+    "from pandas.plotting import scatter_matrix, radviz\n",
     "\n",
     "df = pd.DataFrame(iris.data)\n",
     "df.columns = iris.feature_names\n",
@@ -97,9 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.figure(figsize=(12,12))\n",
@@ -110,9 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df = pd.DataFrame(diabetes.data)\n",
@@ -122,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import random\n",
@@ -153,9 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LinearRegression\n",
@@ -184,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.linear_model import Perceptron\n",
@@ -214,9 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.neighbors import KNeighborsRegressor\n",
@@ -244,9 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.tree import DecisionTreeRegressor\n",
@@ -274,9 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.ensemble import RandomForestRegressor\n",
@@ -304,9 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.ensemble import AdaBoostRegressor\n",
@@ -334,9 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.svm import SVR\n",
@@ -368,9 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.linear_model import Ridge\n",
@@ -398,9 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.linear_model import Lasso\n",
@@ -437,14 +414,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LogisticRegression\n",
     "\n",
-    "splits     = cv.train_test_split(iris.data, iris.target, test_size=0.2)\n",
+    "splits     = train_test_split(iris.data, iris.target, test_size=0.2)\n",
     "X_train, X_test, y_train, y_test = splits\n",
     "\n",
     "model      = LogisticRegression()\n",
@@ -468,14 +443,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.lda import LDA\n",
+    "from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA\n",
     "\n",
-    "splits     = cv.train_test_split(digits.data, digits.target, test_size=0.2)\n",
+    "splits     = train_test_split(digits.data, digits.target, test_size=0.2)\n",
     "X_train, X_test, y_train, y_test = splits\n",
     "\n",
     "model      = LDA()\n",
@@ -499,14 +472,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.naive_bayes import GaussianNB\n",
     "\n",
-    "splits     = cv.train_test_split(iris.data, iris.target, test_size=0.2)\n",
+    "splits     = train_test_split(iris.data, iris.target, test_size=0.2)\n",
     "X_train, X_test, y_train, y_test = splits\n",
     "\n",
     "model      = GaussianNB()\n",
@@ -530,14 +501,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.neighbors import KNeighborsClassifier\n",
     "\n",
-    "splits = cv.train_test_split(digits.data, digits.target, test_size=0.2)\n",
+    "splits = train_test_split(digits.data, digits.target, test_size=0.2)\n",
     "X_train, X_test, y_train, y_test = splits\n",
     "\n",
     "model= KNeighborsClassifier(20)\n",
@@ -563,14 +532,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.tree import DecisionTreeClassifier\n",
     "\n",
-    "splits = cv.train_test_split(iris.data, iris.target, test_size=0.2)\n",
+    "splits = train_test_split(iris.data, iris.target, test_size=0.2)\n",
     "X_train, X_test, y_train, y_test = splits\n",
     "\n",
     "model = DecisionTreeClassifier()\n",
@@ -596,16 +563,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.svm import SVC\n",
     "\n",
     "kernels = ['linear', 'poly', 'rbf']\n",
     "\n",
-    "splits     = cv.train_test_split(digits.data, digits.target, test_size=0.2)\n",
+    "splits     = train_test_split(digits.data, digits.target, test_size=0.2)\n",
     "X_train, X_test, y_train, y_test = splits\n",
     "\n",
     "for kernel in kernels:\n",
@@ -633,14 +598,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.ensemble import RandomForestClassifier\n",
     "\n",
-    "splits     = cv.train_test_split(digits.data, digits.target, test_size=0.2)\n",
+    "splits     = train_test_split(digits.data, digits.target, test_size=0.2)\n",
     "X_train, X_test, y_train, y_test = splits\n",
     "\n",
     "model      = RandomForestClassifier()\n",
@@ -671,9 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.datasets import make_circles\n",
@@ -721,21 +682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.cluster import MiniBatchKMeans\n",
@@ -780,9 +727,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.cluster import AffinityPropagation\n",
@@ -812,8 +757,7 @@
     "    plt.ylabel('$x_1$')\n",
     "    plt.xlabel('$x_0$')\n",
     "\n",
-    "plt.show()\n",
-    "\n"
+    "plt.show()"
    ]
   }
  ],
@@ -833,9 +777,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Made several edits to reflect the latest versions of scikit-learn and pandas.

- Removed `sklearn import cross_validation as cv` and replaced with `from sklearn.model_selection import train_test_split` as `cross_validation` is deprecated since scikit-learn v0.18 and was subsequently removed in v0.20 in favor of `train_test_split` instead. References to `cv` elsewhere in the notebook were also updated.

- Modified `from pandas.tools.plotting import scatter_matrix, radviz` to `pandas.plotting import scatter_matrix, radviz` as `pandas.tools.plotting` was moved to `pandas.plotting` in Pandas v0.20.0.

- Modified `from sklearn.lda import LDA` to `from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA` as the naming for this module was changed in scikit-learn v0.17.
